### PR TITLE
Remove *asana.Client function argument from model's methods

### DIFF
--- a/asana.go
+++ b/asana.go
@@ -1,5 +1,5 @@
 // Package asana provides a client for the Asana API
-package asana // import "bitbucket.org/mikehouston/asana-go"
+package asana
 
 import (
 	"bytes"

--- a/cmd/asana/list.go
+++ b/cmd/asana/list.go
@@ -24,9 +24,9 @@ func ListWorkspaces(c *asana.Client) error {
 	return nil
 }
 
-func ListProjects(client *asana.Client, w *asana.Workspace) error {
+func ListProjects(w *asana.Workspace) error {
 	// List projects
-	projects, err := w.AllProjects(client, &asana.Options{
+	projects, err := w.AllProjects(&asana.Options{
 		Fields: []string{"name", "section_migration_status", "layout"},
 	})
 	if err != nil {
@@ -39,9 +39,9 @@ func ListProjects(client *asana.Client, w *asana.Workspace) error {
 	return nil
 }
 
-func ListTasks(client *asana.Client, p *asana.Project) error {
+func ListTasks(p *asana.Project) error {
 	// List projects
-	tasks, nextPage, err := p.Tasks(client, asana.Fields(asana.Task{}))
+	tasks, nextPage, err := p.Tasks(asana.Fields(asana.Task{}))
 	if err != nil {
 		return err
 	}
@@ -53,9 +53,9 @@ func ListTasks(client *asana.Client, p *asana.Project) error {
 	return nil
 }
 
-func ListSections(client *asana.Client, p *asana.Project) error {
+func ListSections(p *asana.Project) error {
 	// List sections
-	sections, nextPage, err := p.Sections(client)
+	sections, nextPage, err := p.Sections()
 	if err != nil {
 		return err
 	}

--- a/cmd/asana/main.go
+++ b/cmd/asana/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/jessevdk/go-flags"
 	"log"
 	"mime"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"path/filepath"
 
 	"bitbucket.org/mikehouston/asana-go"
+	"github.com/jessevdk/go-flags"
 )
 
 var options struct {
@@ -70,7 +70,7 @@ func main() {
 
 			for _, w := range options.Workspace {
 				workspace := &asana.Workspace{ID: w}
-				check(ListProjects(client, workspace))
+				check(ListProjects(workspace))
 			}
 			return
 		}
@@ -83,12 +83,12 @@ func main() {
 					Name: options.AddSection,
 				}
 
-				_, err := project.CreateSection(client, request)
+				_, err := project.CreateSection(request)
 				check(err)
 				return
 			}
 
-			fmtProject(client, project)
+			fmtProject(project)
 		}
 		return
 	}
@@ -99,22 +99,22 @@ func main() {
 
 		fmt.Printf("Task %s: %q\n", task.ID, task.Name)
 		if options.Attach != "" {
-			addAttachment(task, client)
+			addAttachment(task)
 			return
 		}
 
-		fmtTask(task, client)
+		fmtTask(task)
 	}
 }
 
-func fmtProject(client *asana.Client, project *asana.Project) {
+func fmtProject(project *asana.Project) {
 	fmt.Println("\nSections:")
-	check(ListSections(client, project))
+	check(ListSections(project))
 	fmt.Println("\nTasks:")
-	check(ListTasks(client, project))
+	check(ListTasks(project))
 }
 
-func fmtTask(task *asana.Task, client *asana.Client) {
+func fmtTask(task *asana.Task) {
 	fmt.Printf("  Completed: %v\n", task.Completed)
 	if task.Completed != nil && !*task.Completed {
 		fmt.Printf("  Due: %s\n", task.DueAt)
@@ -123,7 +123,7 @@ func fmtTask(task *asana.Task, client *asana.Client) {
 		fmt.Printf("  Notes: %q\n", task.Notes)
 	}
 	// Get subtasks
-	subtasks, nextPage, err := task.Subtasks(client)
+	subtasks, nextPage, err := task.Subtasks()
 	check(err)
 	_ = nextPage
 	for _, subtask := range subtasks {
@@ -131,11 +131,11 @@ func fmtTask(task *asana.Task, client *asana.Client) {
 	}
 }
 
-func addAttachment(task *asana.Task, client *asana.Client) {
+func addAttachment(task *asana.Task) {
 	f, err := os.Open(options.Attach)
 	check(err)
 	defer f.Close()
-	a, err := task.CreateAttachment(client, &asana.NewAttachment{
+	a, err := task.CreateAttachment(&asana.NewAttachment{
 		Reader:      f,
 		FileName:    f.Name(),
 		ContentType: mime.TypeByExtension(filepath.Ext(f.Name())),

--- a/customfields.go
+++ b/customfields.go
@@ -100,6 +100,7 @@ type CustomFieldBase struct {
 // Users in Asana can lock custom fields, which will make them read-only when accessed by other users.
 // Attempting to edit a locked custom field will return HTTP error code 403 Forbidden.
 type CustomField struct {
+	client *Client
 	// Read-only. Globally unique ID of the object
 	ID string `json:"gid,omitempty"`
 
@@ -128,8 +129,8 @@ type AddCustomFieldSettingRequest struct {
 	InsertAfter  string `json:"insert_after,omitempty"`
 }
 
-func (p *Project) AddCustomFieldSetting(client *Client, request *AddCustomFieldSettingRequest) (*CustomFieldSetting, error) {
-	client.trace("Attach custom field %q to project %q", request.CustomField, p.ID)
+func (p *Project) AddCustomFieldSetting(request *AddCustomFieldSettingRequest) (*CustomFieldSetting, error) {
+	p.client.trace("Attach custom field %q to project %q", request.CustomField, p.ID)
 
 	// Custom request encoding
 	m := map[string]interface{}{}
@@ -149,19 +150,20 @@ func (p *Project) AddCustomFieldSetting(client *Client, request *AddCustomFieldS
 	}
 
 	result := &CustomFieldSetting{}
-	err := client.post(fmt.Sprintf("/projects/%s/addCustomFieldSetting", p.ID), m, result)
+	err := p.client.post(fmt.Sprintf("/projects/%s/addCustomFieldSetting", p.ID), m, result)
+	result.CustomField.client = p.client
 	return result, err
 }
 
-func (p *Project) RemoveCustomFieldSetting(client *Client, customFieldID string) error {
-	client.trace("Remove custom field %q from project %q", customFieldID, p.ID)
+func (p *Project) RemoveCustomFieldSetting(customFieldID string) error {
+	p.client.trace("Remove custom field %q from project %q", customFieldID, p.ID)
 
 	// Custom request encoding
 	m := map[string]interface{}{
 		"custom_field": customFieldID,
 	}
 
-	err := client.post(fmt.Sprintf("/projects/%s/removeCustomFieldSetting", p.ID), m, &json.RawMessage{})
+	err := p.client.post(fmt.Sprintf("/projects/%s/removeCustomFieldSetting", p.ID), m, &json.RawMessage{})
 	return err
 }
 
@@ -181,6 +183,7 @@ func (c *Client) CreateCustomField(request *CreateCustomFieldRequest) (*CustomFi
 
 	result := &CustomField{}
 	err := c.post("/custom_fields", request, result)
+	result.client = c
 	return result, err
 }
 
@@ -208,25 +211,28 @@ type CustomFieldValue struct {
 }
 
 // Fetch loads the full details for this CustomField
-func (f *CustomField) Fetch(client *Client, options ...*Options) error {
-	client.trace("Loading details for custom field %q", f.ID)
+func (f *CustomField) Fetch(options ...*Options) error {
+	f.client.trace("Loading details for custom field %q", f.ID)
 
-	_, err := client.get(fmt.Sprintf("/custom_fields/%s", f.ID), nil, f, options...)
+	_, err := f.client.get(fmt.Sprintf("/custom_fields/%s", f.ID), nil, f, options...)
 	return err
 }
 
 // CustomFields returns the compact records for all custom fields in the workspace
-func (w *Workspace) CustomFields(client *Client, options ...*Options) ([]*CustomField, *NextPage, error) {
-	client.trace("Listing custom fields in workspace %s...\n", w.ID)
+func (w *Workspace) CustomFields(options ...*Options) ([]*CustomField, *NextPage, error) {
+	w.client.trace("Listing custom fields in workspace %s...\n", w.ID)
 	var result []*CustomField
 
 	// Make the request
-	nextPage, err := client.get(fmt.Sprintf("/workspaces/%s/custom_fields", w.ID), nil, &result, options...)
+	nextPage, err := w.client.get(fmt.Sprintf("/workspaces/%s/custom_fields", w.ID), nil, &result, options...)
+	for _, r := range result {
+		r.client = w.client
+	}
 	return result, nextPage, err
 }
 
 // AllCustomFields repeatedly pages through all available custom fields in a workspace
-func (w *Workspace) AllCustomFields(client *Client, options ...*Options) ([]*CustomField, error) {
+func (w *Workspace) AllCustomFields(options ...*Options) ([]*CustomField, error) {
 	var allCustomFields []*CustomField
 	nextPage := &NextPage{}
 
@@ -240,7 +246,7 @@ func (w *Workspace) AllCustomFields(client *Client, options ...*Options) ([]*Cus
 		}
 
 		allOptions := append([]*Options{page}, options...)
-		customFields, nextPage, err = w.CustomFields(client, allOptions...)
+		customFields, nextPage, err = w.CustomFields(allOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/portfolios.go
+++ b/portfolios.go
@@ -1,15 +1,14 @@
 package asana
 
-import "fmt"
-
 type Portfolio struct {
+	client *Client
 	// Read-only. Globally unique ID of the object
 	ID string `json:"gid,omitempty"`
 }
 
 // Projects returns a list of projects in this workspace
-func (w *Workspace) Portfolios(client *Client, options ...*Options) ([]*Portfolio, *NextPage, error) {
-	client.trace("Listing portfolios in %q", w.Name)
+func (w *Workspace) Portfolios(options ...*Options) ([]*Portfolio, *NextPage, error) {
+	w.client.trace("Listing portfolios in %q", w.Name)
 
 	var result []*Portfolio
 
@@ -19,6 +18,9 @@ func (w *Workspace) Portfolios(client *Client, options ...*Options) ([]*Portfoli
 	}
 
 	// Make the request
-	nextPage, err := client.get(fmt.Sprintf("/portfolios"), nil, &result, append(options, o)...)
+	nextPage, err := w.client.get("/portfolios", nil, &result, append(options, o)...)
+	for _, r := range result {
+		r.client = w.client
+	}
 	return result, nextPage, err
 }

--- a/projects.go
+++ b/projects.go
@@ -115,6 +115,8 @@ const (
 // project will add them as members if they are not already, removing
 // followers from a project will not affect membership.
 type Project struct {
+	client *Client
+
 	// Read-only. Globally unique ID of the object
 	ID string `json:"gid,omitempty"`
 
@@ -165,10 +167,10 @@ type Project struct {
 }
 
 // Fetch loads the full details for this Project
-func (p *Project) Fetch(client *Client, opts ...*Options) error {
-	client.trace("Loading project details for %q", p.Name)
+func (p *Project) Fetch(opts ...*Options) error {
+	p.client.trace("Loading project details for %q", p.Name)
 
-	_, err := client.get(fmt.Sprintf("/projects/%s", p.ID), nil, p, opts...)
+	_, err := p.client.get(fmt.Sprintf("/projects/%s", p.ID), nil, p, opts...)
 	return err
 }
 
@@ -178,21 +180,24 @@ func (p *Project) Fetch(client *Client, opts ...*Options) error {
 // or else you may overwrite changes made by another user since you last retrieved the task.
 //
 // Updates the referenced project object
-func (p *Project) Update(client *Client, request *UpdateProjectRequest, opts ...*Options) error {
-	client.trace("Update project %q", p.Name)
+func (p *Project) Update(request *UpdateProjectRequest, opts ...*Options) error {
+	p.client.trace("Update project %q", p.Name)
 
-	err := client.put(fmt.Sprintf("/projects/%s", p.ID), request, p, opts...)
+	err := p.client.put(fmt.Sprintf("/projects/%s", p.ID), request, p, opts...)
 	return err
 }
 
 // Projects returns a list of projects in this workspace
-func (w *Workspace) Projects(client *Client, options ...*Options) ([]*Project, *NextPage, error) {
-	client.trace("Listing projects in %q", w.Name)
+func (w *Workspace) Projects(options ...*Options) ([]*Project, *NextPage, error) {
+	w.client.trace("Listing projects in %q", w.Name)
 
 	var result []*Project
 
 	// Make the request
-	nextPage, err := client.get(fmt.Sprintf("/workspaces/%s/projects", w.ID), nil, &result, options...)
+	nextPage, err := w.client.get(fmt.Sprintf("/workspaces/%s/projects", w.ID), nil, &result, options...)
+	for _, r := range result {
+		r.client = w.client
+	}
 	return result, nextPage, err
 }
 
@@ -202,8 +207,8 @@ type favoritesRequestParams struct {
 }
 
 // FavoriteProjects returns a list of the current user's favorite projects in this workspace
-func (w *Workspace) FavoriteProjects(client *Client, options ...*Options) ([]*Project, *NextPage, error) {
-	client.trace("Listing favorite projects in %q", w.Name)
+func (w *Workspace) FavoriteProjects(options ...*Options) ([]*Project, *NextPage, error) {
+	w.client.trace("Listing favorite projects in %q", w.Name)
 
 	var result []*Project
 
@@ -212,16 +217,19 @@ func (w *Workspace) FavoriteProjects(client *Client, options ...*Options) ([]*Pr
 		ResourceType: "project",
 		Workspace:    w.ID,
 	}
-	user, err := client.CurrentUser()
+	user, err := w.client.CurrentUser()
 	if err != nil {
 		return nil, nil, err
 	}
-	nextPage, err := client.get(fmt.Sprintf("/users/%s/favorites", user.ID), query, &result, options...)
+	nextPage, err := w.client.get(fmt.Sprintf("/users/%s/favorites", user.ID), query, &result, options...)
+	for _, r := range result {
+		r.client = w.client
+	}
 	return result, nextPage, err
 }
 
 // AllProjects repeatedly pages through all available projects in a workspace
-func (w *Workspace) AllProjects(client *Client, options ...*Options) ([]*Project, error) {
+func (w *Workspace) AllProjects(options ...*Options) ([]*Project, error) {
 	var allProjects []*Project
 	nextPage := &NextPage{}
 
@@ -235,7 +243,7 @@ func (w *Workspace) AllProjects(client *Client, options ...*Options) ([]*Project
 		}
 
 		allOptions := append([]*Options{page}, options...)
-		projects, nextPage, err = w.Projects(client, allOptions...)
+		projects, nextPage, err = w.Projects(allOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -246,7 +254,7 @@ func (w *Workspace) AllProjects(client *Client, options ...*Options) ([]*Project
 }
 
 // AllProjects repeatedly pages through all available projects in a workspace
-func (w *Workspace) AllFavoriteProjects(client *Client, options ...*Options) ([]*Project, error) {
+func (w *Workspace) AllFavoriteProjects(options ...*Options) ([]*Project, error) {
 	var allProjects []*Project
 	nextPage := &NextPage{}
 
@@ -260,7 +268,7 @@ func (w *Workspace) AllFavoriteProjects(client *Client, options ...*Options) ([]
 		}
 
 		allOptions := append([]*Options{page}, options...)
-		projects, nextPage, err = w.FavoriteProjects(client, allOptions...)
+		projects, nextPage, err = w.FavoriteProjects(allOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -271,18 +279,21 @@ func (w *Workspace) AllFavoriteProjects(client *Client, options ...*Options) ([]
 }
 
 // Projects returns a list of projects in this team
-func (t *Team) Projects(client *Client, options ...*Options) ([]*Project, *NextPage, error) {
-	client.trace("Listing projects in %q", t.Name)
+func (t *Team) Projects(options ...*Options) ([]*Project, *NextPage, error) {
+	t.client.trace("Listing projects in %q", t.Name)
 
 	var result []*Project
 
 	// Make the request
-	nextPage, err := client.get(fmt.Sprintf("/teams/%s/projects", t.ID), nil, &result, options...)
+	nextPage, err := t.client.get(fmt.Sprintf("/teams/%s/projects", t.ID), nil, &result, options...)
+	for _, r := range result {
+		r.client = t.client
+	}
 	return result, nextPage, err
 }
 
 // AllProjects repeatedly pages through all available projects in a team
-func (t *Team) AllProjects(client *Client, options ...*Options) ([]*Project, error) {
+func (t *Team) AllProjects(options ...*Options) ([]*Project, error) {
 	var allProjects []*Project
 	nextPage := &NextPage{}
 
@@ -296,7 +307,7 @@ func (t *Team) AllProjects(client *Client, options ...*Options) ([]*Project, err
 		}
 
 		allOptions := append([]*Options{page}, options...)
-		projects, nextPage, err = t.Projects(client, allOptions...)
+		projects, nextPage, err = t.Projects(allOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -323,5 +334,6 @@ func (t *Team) CreateProject(c *Client, project *CreateProjectRequest) (*Project
 	result := &Project{}
 
 	err := c.post(fmt.Sprintf("/teams/%s/projects", t.ID), project, result)
+	result.client = c
 	return result, err
 }

--- a/teams.go
+++ b/teams.go
@@ -7,6 +7,7 @@ import (
 // Team is used to group related projects and people together within an
 // organization. Each project in an organization is associated with a team.
 type Team struct {
+	client *Client
 
 	// Read-only. Globally unique ID of the object
 	ID string `json:"gid,omitempty"`
@@ -33,17 +34,20 @@ func (t *Team) Fetch(client *Client) error {
 }
 
 // Teams returns the compact records for all teams in the organization visible to the authorized user
-func (w *Workspace) Teams(client *Client, options ...*Options) ([]*Team, *NextPage, error) {
-	client.trace("Listing teams in workspace %s...\n", w.ID)
+func (w *Workspace) Teams(options ...*Options) ([]*Team, *NextPage, error) {
+	w.client.trace("Listing teams in workspace %s...\n", w.ID)
 	var result []*Team
 
 	// Make the request
-	nextPage, err := client.get(fmt.Sprintf("/organizations/%s/teams", w.ID), nil, &result, options...)
+	nextPage, err := w.client.get(fmt.Sprintf("/organizations/%s/teams", w.ID), nil, &result, options...)
+	for _, r := range result {
+		r.client = w.client
+	}
 	return result, nextPage, err
 }
 
 // AllTeams repeatedly pages through all available teams in a workspace
-func (w *Workspace) AllTeams(client *Client, options ...*Options) ([]*Team, error) {
+func (w *Workspace) AllTeams(options ...*Options) ([]*Team, error) {
 	var allTeams []*Team
 	nextPage := &NextPage{}
 
@@ -57,7 +61,7 @@ func (w *Workspace) AllTeams(client *Client, options ...*Options) ([]*Team, erro
 		}
 
 		allOptions := append([]*Options{page}, options...)
-		teams, nextPage, err = w.Teams(client, allOptions...)
+		teams, nextPage, err = w.Teams(allOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/workspaces.go
+++ b/workspaces.go
@@ -19,6 +19,7 @@ import (
 // announcements, you can still reference organizations in any workspace
 // parameter.
 type Workspace struct {
+	client *Client
 
 	// Read-only. Globally unique ID of the object
 	ID string `json:"gid,omitempty"`
@@ -49,12 +50,15 @@ func (c *Client) Workspaces(options ...*Options) ([]*Workspace, *NextPage, error
 
 	// Make the request
 	nextPage, err := c.get("/workspaces", nil, &result, options...)
+	for _, r := range result {
+		r.client = c
+	}
 	return result, nextPage, err
 }
 
 // AllWorkspaces repeatedly pages through all available workspaces for a client
 func (c *Client) AllWorkspaces(options ...*Options) ([]*Workspace, error) {
-	allWorkspaces := []*Workspace{}
+	var allWorkspaces []*Workspace
 	nextPage := &NextPage{}
 
 	var workspaces []*Workspace


### PR DESCRIPTION
Before this PR every method of asana's model needed to pass `*asana.Client`. Now it's embedded inside structs and there is no need for that. 

When new models are creating they inherit the embedded `client` field from the creator.