### PR TITLE
Migrate bitbucket references to github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This release addresses critical security vulnerabilities in the Go standard libr
 ### Upgrade Instructions
 
 1. Update your Go installation to 1.24.4 or later
-2. Run `go get -u bitbucket.org/mikehouston/asana-go` to get the latest version
+2. Run `go get -u github.com/kothar/asana-go` to get the latest version
 3. Run `go mod tidy` to ensure dependencies are updated
 4. Test your application thoroughly after updating
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ import (
     "context"
     "net/http"
     "time"
-    "bitbucket.org/mikehouston/asana-go"
+    "github.com/kothar/asana-go"
 )
 
 func main() {

--- a/asana.go
+++ b/asana.go
@@ -1,5 +1,5 @@
 // Package asana provides a client for the Asana API
-package asana // import "bitbucket.org/mikehouston/asana-go"
+package asana // import "github.com/kothar/asana-go"
 
 import (
 	"bytes"

--- a/cmd/asana/list.go
+++ b/cmd/asana/list.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"fmt"
+    "fmt"
 
-	"bitbucket.org/mikehouston/asana-go"
+    "github.com/kothar/asana-go"
 )
 
 func ListWorkspaces(c *asana.Client) error {

--- a/cmd/asana/main.go
+++ b/cmd/asana/main.go
@@ -11,7 +11,7 @@ import (
     "os"
     "path/filepath"
 
-    "bitbucket.org/mikehouston/asana-go"
+    "github.com/kothar/asana-go"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bitbucket.org/mikehouston/asana-go
+module github.com/kothar/asana-go
 
 go 1.24.4
 


### PR DESCRIPTION
Migrate all Bitbucket references to the GitHub repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-bac1a4ca-c0ba-4ade-8c62-a2fdea137fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bac1a4ca-c0ba-4ade-8c62-a2fdea137fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

