### PR TITLE
Add asana_created_field property to CustomField

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,14 +28,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        # govulncheck@latest tracks the latest Go release, so run the security
-        # scan on the current stable toolchain. The build/test job above still
-        # validates against the module's declared minimum Go version.
-        go-version: 'stable'
-
+    # govulncheck-action sets up Go itself. govulncheck@latest tracks the latest
+    # Go release, so run the security scan on the current stable toolchain. The
+    # build/test job above still validates against the module's declared minimum
+    # Go version.
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,12 +31,15 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24.4'
+        # govulncheck@latest tracks the latest Go release, so run the security
+        # scan on the current stable toolchain. The build/test job above still
+        # validates against the module's declared minimum Go version.
+        go-version: 'stable'
 
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: '1.24.4'
+        go-version-input: 'stable'
         go-package: './...'
 
     - name: Run gosec Security Scanner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GO-2025-3488: Fixed unexpected memory consumption during token parsing vulnerability
 
 ### Added
+- Added the read-only `asana_created_field` property to `CustomField`, along with an
+  `IsAsanaCreated()` helper, so callers can detect fields that Asana creates and manages
+  automatically (e.g. "Priority", "Status") and which cannot be created through the API
 - Added comprehensive security scanning to CI/CD pipeline:
   - `govulncheck` for Go vulnerability scanning
   - Trivy for dependency and container vulnerability scanning

--- a/customfields.go
+++ b/customfields.go
@@ -127,6 +127,20 @@ type CustomField struct {
 	// Determines whether the custom field is available for editing on a task
 	// (i.e. the field is associated with one of the task's parent projects)
 	Enabled *bool `json:"enabled,omitempty"`
+
+	// Read-only. If this custom field is one that Asana creates and manages
+	// automatically (for example the built-in "Priority" and "Status" fields),
+	// this holds the non-empty identifier of that Asana-created field. It is
+	// empty for user-created custom fields. Custom fields with a non-empty value
+	// here cannot be created through the API.
+	AsanaCreatedField string `json:"asana_created_field,omitempty"`
+}
+
+// IsAsanaCreated reports whether this custom field is one that Asana creates and
+// manages automatically (such as the built-in "Priority" and "Status" fields).
+// Such fields cannot be recreated through the API.
+func (f *CustomField) IsAsanaCreated() bool {
+	return f.AsanaCreatedField != ""
 }
 
 type CustomFieldSetting struct {

--- a/customfields_test.go
+++ b/customfields_test.go
@@ -47,3 +47,57 @@ func TestCustomFieldBase_Precision_SerializeZero(t *testing.T) {
     }
 
 }
+
+func TestCustomField_AsanaCreatedField_Parse(t *testing.T) {
+    cf := &CustomField{}
+    if err := json.Unmarshal([]byte(`
+{
+	"gid": "123",
+	"name": "Priority",
+	"resource_subtype": "enum",
+	"asana_created_field": "priority"
+}
+`), cf); err != nil {
+        t.Fatal(err)
+    }
+
+    if cf.AsanaCreatedField != "priority" {
+        t.Errorf("Expected AsanaCreatedField to be %q, but saw %q", "priority", cf.AsanaCreatedField)
+    }
+    if !cf.IsAsanaCreated() {
+        t.Errorf("Expected IsAsanaCreated to be true for an Asana-created field")
+    }
+}
+
+func TestCustomField_AsanaCreatedField_Absent(t *testing.T) {
+    cf := &CustomField{}
+    if err := json.Unmarshal([]byte(`
+{
+	"gid": "123",
+	"name": "Effort",
+	"resource_subtype": "number"
+}
+`), cf); err != nil {
+        t.Fatal(err)
+    }
+
+    if cf.AsanaCreatedField != "" {
+        t.Errorf("Expected AsanaCreatedField to be empty, but saw %q", cf.AsanaCreatedField)
+    }
+    if cf.IsAsanaCreated() {
+        t.Errorf("Expected IsAsanaCreated to be false for a user-created field")
+    }
+}
+
+// TestCustomField_AsanaCreatedField_RequestedInFields ensures the read-only
+// asana_created_field property is included in opt_fields when requesting all
+// fields for a CustomField, so it is populated on reads.
+func TestCustomField_AsanaCreatedField_RequestedInFields(t *testing.T) {
+    options := Fields(CustomField{})
+    for _, name := range options.Fields {
+        if name == "asana_created_field" {
+            return
+        }
+    }
+    t.Errorf("Expected Fields(CustomField{}) to include %q, got %v", "asana_created_field", options.Fields)
+}


### PR DESCRIPTION
## Summary

Asana automatically creates and manages certain custom fields, such as the built-in **Priority** and **Status** fields. The API exposes a read-only [`asana_created_field`](https://developers.asana.com/reference/custom-fields) property that is non-empty for these Asana-managed fields and empty for user-created ones. Critically, fields with this property set **cannot be created through the API**.

This PR exposes that property so callers can detect and correctly handle these fields (e.g. skip creation, or attach the existing field by its stable ID) instead of attempting an impossible create that the API rejects.

## Changes

- Add `AsanaCreatedField string` (`json:"asana_created_field,omitempty"`) to `CustomField`. It is placed on `CustomField` rather than the embedded `CustomFieldBase` so that it is **not** sent in create/update request bodies (which embed `CustomFieldBase`).
- Add an `IsAsanaCreated()` helper method.
- Because `opt_fields` are gathered by reflecting over struct json tags (`reflect.go`), adding the field automatically causes it to be requested and populated on reads — no other wiring required.
- Add unit tests covering parsing when the property is present/absent, the `IsAsanaCreated()` helper, and that `Fields(CustomField{})` includes `asana_created_field`.
- Add a CHANGELOG entry.

## Testing

`go test ./...` passes and `gofmt` reports no changes for the modified source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSGHJwQXVBC2qkLGuQYrvR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying Asana-managed custom fields in read responses.
  * Introduced a helper to check whether a custom field is Asana-created.
  * Included the new read-only field in field selection so it’s returned when fetching data.

* **Documentation**
  * Updated the changelog to reflect the new custom field support.

* **Tests**
  * Added coverage for parsing, absence handling, and requesting the new custom field property.

* **Chores**
  * Updated vulnerability scanning to use the latest stable Go toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->