### PR TITLE
Replace pkg/errors with Go standard library equivalents

### DIFF
--- a/asana.go
+++ b/asana.go
@@ -87,7 +87,7 @@ func (c *Client) getURL(path string) string {
 func mergeQuery(q url.Values, request interface{}) error {
 	queryParams, err := query.Values(request)
 	if err != nil {
-		return fmt.Errorf("Unable to marshal request to query parameters: %w", err)
+		return fmt.Errorf("unable to marshal request to query parameters: %w", err)
 	}
 
 	// Merge with defaults
@@ -116,7 +116,7 @@ func (c *Client) get(path string, data, result interface{}, opts ...*Options) (*
 	}
 	q, err := query.Values(c.DefaultOptions)
 	if err != nil {
-		return nil, fmt.Errorf("%s Unable to marshal DefaultOptions to query parameters: %w", requestID, err)
+		return nil, fmt.Errorf("%s unable to marshal DefaultOptions to query parameters: %w", requestID, err)
 	}
 
 	// Encode data
@@ -156,7 +156,7 @@ func (c *Client) get(path string, data, result interface{}, opts ...*Options) (*
 	}
 	request, err := http.NewRequest(http.MethodGet, c.getURL(path), nil)
 	if err != nil {
-		return nil, fmt.Errorf("%s Request error: %w", requestID, err)
+		return nil, fmt.Errorf("%s request error: %w", requestID, err)
 	}
 	c.addHeaders(request, options)
 	resp, err := c.HTTPClient.Do(request)
@@ -245,7 +245,7 @@ func (c *Client) do(method, path string, data, result interface{}, opts ...*Opti
 	}
 	request, err := http.NewRequest(method, c.getURL(path), bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("Request error: %w", err)
+		return fmt.Errorf("request error: %w", err)
 	}
 
 	request.Header.Add("Content-Type", "application/json")
@@ -319,7 +319,7 @@ func (c *Client) postMultipart(path string, result interface{}, field string, r 
 		r,
 		bytes.NewReader(buffer.Bytes()[headerSize:])))
 	if err != nil {
-		return fmt.Errorf("%s Request error: %w", requestID, err)
+		return fmt.Errorf("%s request error: %w", requestID, err)
 	}
 
 	request.Header.Add("Content-Type", partWriter.FormDataContentType())
@@ -368,7 +368,7 @@ func (c *Client) parseResponse(resp *http.Response, result interface{}, requestI
 
 	// Decode the data field
 	if value.Data == nil {
-		return nil, fmt.Errorf("%s Missing data from response", requestID)
+		return nil, fmt.Errorf("%s missing data from response", requestID)
 	}
 
 	return value, c.parseResponseData(value.Data, result, requestID)
@@ -380,7 +380,7 @@ func (c *Client) parseResponseData(data []byte, result interface{}, requestID xi
 	}
 
 	if err := json.Unmarshal(data, result); err != nil {
-		return fmt.Errorf("%s Unable to parse response data: %w", requestID, err)
+		return fmt.Errorf("%s unable to parse response data: %w", requestID, err)
 	}
 
 	return nil

--- a/asana.go
+++ b/asana.go
@@ -17,7 +17,6 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/google/go-querystring/query"
-	"github.com/pkg/errors"
 	"github.com/rs/xid"
 )
 
@@ -88,7 +87,7 @@ func (c *Client) getURL(path string) string {
 func mergeQuery(q url.Values, request interface{}) error {
 	queryParams, err := query.Values(request)
 	if err != nil {
-		return errors.Wrap(err, "Unable to marshal request to query parameters")
+		return fmt.Errorf("Unable to marshal request to query parameters: %w", err)
 	}
 
 	// Merge with defaults
@@ -108,7 +107,7 @@ func (c *Client) get(path string, data, result interface{}, opts ...*Options) (*
 	// Prepare options
 	options, err := c.mergeOptions(opts...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s unable to merge options", requestID)
+		return nil, fmt.Errorf("%s unable to merge options: %w", requestID, err)
 	}
 
 	// Encode default options
@@ -117,7 +116,7 @@ func (c *Client) get(path string, data, result interface{}, opts ...*Options) (*
 	}
 	q, err := query.Values(c.DefaultOptions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s Unable to marshal DefaultOptions to query parameters", requestID)
+		return nil, fmt.Errorf("%s Unable to marshal DefaultOptions to query parameters: %w", requestID, err)
 	}
 
 	// Encode data
@@ -157,12 +156,12 @@ func (c *Client) get(path string, data, result interface{}, opts ...*Options) (*
 	}
 	request, err := http.NewRequest(http.MethodGet, c.getURL(path), nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s Request error", requestID)
+		return nil, fmt.Errorf("%s Request error: %w", requestID, err)
 	}
 	c.addHeaders(request, options)
 	resp, err := c.HTTPClient.Do(request)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s GET error", requestID)
+		return nil, fmt.Errorf("%s GET error: %w", requestID, err)
 	}
 
 	// Parse the result
@@ -217,7 +216,7 @@ func (c *Client) do(method, path string, data, result interface{}, opts ...*Opti
 	// Prepare options
 	options, err := c.mergeOptions(opts...)
 	if err != nil {
-		return errors.Wrapf(err, "%s unable to merge options", requestID)
+		return fmt.Errorf("%s unable to merge options: %w", requestID, err)
 	}
 
 	// Validate data
@@ -246,14 +245,14 @@ func (c *Client) do(method, path string, data, result interface{}, opts ...*Opti
 	}
 	request, err := http.NewRequest(method, c.getURL(path), bytes.NewReader(body))
 	if err != nil {
-		return errors.Wrap(err, "Request error")
+		return fmt.Errorf("Request error: %w", err)
 	}
 
 	request.Header.Add("Content-Type", "application/json")
 	c.addHeaders(request, options)
 	resp, err := c.HTTPClient.Do(request)
 	if err != nil {
-		return errors.Wrapf(err, "%s error", method)
+		return fmt.Errorf("%s error: %w", method, err)
 	}
 
 	_, err = c.parseResponse(resp, result, requestID, options)
@@ -286,7 +285,7 @@ func (c *Client) postMultipart(path string, result interface{}, field string, r 
 	requestID := xid.New()
 	options, err := c.mergeOptions(opts...)
 	if err != nil {
-		return errors.Wrapf(err, "%s unable to merge options", requestID)
+		return fmt.Errorf("%s unable to merge options: %w", requestID, err)
 	}
 
 	if IsTrue(options.Debug) {
@@ -305,13 +304,13 @@ func (c *Client) postMultipart(path string, result interface{}, field string, r 
 
 	_, err = partWriter.CreatePart(h)
 	if err != nil {
-		return errors.Wrapf(err, "%s create multipart header", requestID)
+		return fmt.Errorf("%s create multipart header: %w", requestID, err)
 	}
 	headerSize := buffer.Len()
 
 	// Write footer
 	if err = partWriter.Close(); err != nil {
-		return errors.Wrapf(err, "%s create multipart footer", requestID)
+		return fmt.Errorf("%s create multipart footer: %w", requestID, err)
 	}
 
 	// Create request
@@ -320,14 +319,14 @@ func (c *Client) postMultipart(path string, result interface{}, field string, r 
 		r,
 		bytes.NewReader(buffer.Bytes()[headerSize:])))
 	if err != nil {
-		return errors.Wrapf(err, "%s Request error", requestID)
+		return fmt.Errorf("%s Request error: %w", requestID, err)
 	}
 
 	request.Header.Add("Content-Type", partWriter.FormDataContentType())
 	c.addHeaders(request, options)
 	resp, err := c.HTTPClient.Do(request)
 	if err != nil {
-		return errors.Wrapf(err, "%s POST error", requestID)
+		return fmt.Errorf("%s POST error: %w", requestID, err)
 	}
 
 	_, err = c.parseResponse(resp, result, requestID, options)
@@ -369,7 +368,7 @@ func (c *Client) parseResponse(resp *http.Response, result interface{}, requestI
 
 	// Decode the data field
 	if value.Data == nil {
-		return nil, errors.Errorf("%s Missing data from response", requestID)
+		return nil, fmt.Errorf("%s Missing data from response", requestID)
 	}
 
 	return value, c.parseResponseData(value.Data, result, requestID)
@@ -381,7 +380,7 @@ func (c *Client) parseResponseData(data []byte, result interface{}, requestID xi
 	}
 
 	if err := json.Unmarshal(data, result); err != nil {
-		return errors.Wrapf(err, "%s Unable to parse response data", requestID)
+		return fmt.Errorf("%s Unable to parse response data: %w", requestID, err)
 	}
 
 	return nil

--- a/attachments.go
+++ b/attachments.go
@@ -2,7 +2,6 @@ package asana
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"time"
 )
@@ -86,7 +85,7 @@ func (t *Task) CreateAttachment(client *Client, request *NewAttachment) (*Attach
 	result := &Attachment{}
 	err := client.postMultipart(fmt.Sprintf("/tasks/%s/attachments", t.ID), result, "file", request.Reader, request.FileName, request.ContentType)
 	if err != nil {
-		return nil, errors.Wrap(err, "Upload attachment")
+		return nil, fmt.Errorf("Upload attachment: %w", err)
 	}
 	return result, nil
 }
@@ -105,7 +104,7 @@ func (t *Task) CreateExternalAttachment(client *Client, request *ExternalAttachm
 	result := &Attachment{}
 	err := client.post(fmt.Sprintf("/tasks/%s/attachments", t.ID), request, result)
 	if err != nil {
-		return nil, errors.Wrap(err, "Create external attachment")
+		return nil, fmt.Errorf("Create external attachment: %w", err)
 	}
 	return result, nil
 }

--- a/attachments.go
+++ b/attachments.go
@@ -85,7 +85,7 @@ func (t *Task) CreateAttachment(client *Client, request *NewAttachment) (*Attach
 	result := &Attachment{}
 	err := client.postMultipart(fmt.Sprintf("/tasks/%s/attachments", t.ID), result, "file", request.Reader, request.FileName, request.ContentType)
 	if err != nil {
-		return nil, fmt.Errorf("Upload attachment: %w", err)
+		return nil, fmt.Errorf("upload attachment: %w", err)
 	}
 	return result, nil
 }
@@ -104,7 +104,7 @@ func (t *Task) CreateExternalAttachment(client *Client, request *ExternalAttachm
 	result := &Attachment{}
 	err := client.post(fmt.Sprintf("/tasks/%s/attachments", t.ID), request, result)
 	if err != nil {
-		return nil, fmt.Errorf("Create external attachment: %w", err)
+		return nil, fmt.Errorf("create external attachment: %w", err)
 	}
 	return result, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -1,12 +1,12 @@
 package asana
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rs/xid"
 )
 
@@ -50,8 +50,8 @@ func (err Error) Error() string {
 }
 
 func IsAsanaError(err error) (*Error, bool) {
-	cause := errors.Cause(err)
-	if e, ok := cause.(*Error); ok {
+	var e *Error
+	if errors.As(err, &e) {
 		return e, true
 	}
 	return nil, false

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,16 +1,15 @@
 package asana
 
 import (
+	"fmt"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestCauseWrappedError(t *testing.T) {
 	cause := &Error{StatusCode: 500}
 
-	wrap1 := errors.Wrap(cause, "Wrapping 1")
-	wrap2 := errors.Wrap(wrap1, "Wrapping 2")
+	wrap1 := fmt.Errorf("Wrapping 1: %w", cause)
+	wrap2 := fmt.Errorf("Wrapping 2: %w", wrap1)
 
 	if !IsRecoverableError(cause) {
 		t.Error("Expected original error to be recoverable")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/h2non/gock v1.2.0
 	github.com/jessevdk/go-flags v1.6.1
-	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.6.0
 	golang.org/x/oauth2 v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bB
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 golang.org/x/oauth2 v0.32.0 h1:jsCblLleRMDrxMN29H3z/k1KliIvpLgCkE6R8FXXNgY=


### PR DESCRIPTION
## Motivation

The `github.com/pkg/errors` package has been archived and is no longer maintained. The Go standard library now provides equivalent functionality via `fmt.Errorf` with the `%w` verb and `errors.As`/`errors.Is` for error chain inspection.

## Approach

All usages of `pkg/errors` across three source files and one test file were replaced with stdlib equivalents:

- `errors.Wrap(err, "msg")` and `errors.Wrapf(err, "fmt", args)` replaced with `fmt.Errorf("msg: %w", err)`
- `errors.Errorf("fmt", args)` replaced with `fmt.Errorf("fmt", args)`
- `errors.Cause(err)` replaced with `errors.As(err, &target)`, which correctly walks the full error chain just as `Cause` did
- `pkg/errors` removed from imports and from `go.mod`/`go.sum` via `go mod tidy`

## Notes

- The `%w` verb preserves error wrapping semantics, so `errors.As` and `errors.Is` continue to work through wrapped error chains.
- All existing tests pass with no changes to test assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and propagation across API requests, attachments/uploads, and response parsing.
  * Error wrapping now preserves the original cause using standard wrapped errors, including multi-layer scenarios.
  * Updated attachment error context for clearer, consistent messaging.
* **Chores**
  * Removed the third-party error-handling dependency in favor of Go’s standard library.
* **Tests**
  * Updated error-wrapping expectations and utilities to match the new standard library behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->